### PR TITLE
Switch back to 20.04 for Linux builds

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,14 +13,14 @@ jobs:
       matrix:
         platform:
           - release_for: Linux-x86_64
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             bin: transport
             name: transport-Linux-x86_64.tar.gz
             command: build
 
           - release_for: Linux-aarch64
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             bin: transport
             name: transport-Linux-aarch64.tar.gz


### PR DESCRIPTION
For GLIBC compatibility or else we may get errors like this when using the transport with newer versions of GLIBC:

/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found